### PR TITLE
seriesAll support tuple type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # deverything
 
+## 1.8.1
+
+### Patch Changes
+
+- seriesAll support tuple type
+
 ## 1.8.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deverything",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Everything you need for Dev",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
To support this:

```ts
seriesAll([Promise.resolve(1), Promise.resolve('foo')]
// Promise<[number, string]>
```

Which before would error with:
```
Type 'Promise<string>' is not assignable to type 'Promise<number> | (() => Promise<number>)'.
  Type 'Promise<string>' is not assignable to type 'Promise<number>'.
    Type 'string' is not assignable to type 'number'.ts(2322)
```