### PR TITLE
Add JSDoc to `arrayDiff`

### DIFF
--- a/src/helpers/arrayDiff.ts
+++ b/src/helpers/arrayDiff.ts
@@ -1,10 +1,13 @@
 import { uniqueValues } from "./uniqueValues";
 
-// TODO: optimize with maps?
+/**
+ * Given 2 arrays, returns the elements that belong to each but not both at the same time.
+ */
 export const arrayDiff = (arr1: any[], arr2: any[]) => {
+  // TODO: optimize with maps?
   return uniqueValues(
     arr1
       .filter((value) => !arr2.includes(value))
-      .concat(arr2.filter((value) => !arr1.includes(value)))
+      .concat(arr2.filter((value) => !arr1.includes(value))),
   );
 };


### PR DESCRIPTION
Add description JSDoc to `arrayDiff` for clarification and avoiding misinterpretations of its purpose and result.