### PR TITLE
New helper formatFileSize

### DIFF
--- a/src/helpers/formatFileSize.test.ts
+++ b/src/helpers/formatFileSize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatFileSize } from "./formatFileSize";
+
+describe("formatFileSize", () => {
+  it("defaults to KB", () => {
+    expect(formatFileSize(2048)).toBe("2 KB");
+  });
+
+  it("rounds to the nearest whole unit", () => {
+    expect(formatFileSize(1536)).toBe("2 KB"); // 1.5 KB rounds up
+    expect(formatFileSize(1480)).toBe("1 KB"); // 1.44 KB rounds down
+  });
+
+  it("never returns less than 1 of the unit", () => {
+    expect(formatFileSize(0)).toBe("1 KB");
+    expect(formatFileSize(10)).toBe("1 KB");
+    expect(formatFileSize(0, "B")).toBe("1 B");
+  });
+
+  it("formats bytes", () => {
+    expect(formatFileSize(500, "B")).toBe("500 B");
+  });
+
+  it("formats KB", () => {
+    expect(formatFileSize(1024, "KB")).toBe("1 KB");
+    expect(formatFileSize(1024 * 10, "KB")).toBe("10 KB");
+  });
+
+  it("formats MB", () => {
+    expect(formatFileSize(1024 ** 2, "MB")).toBe("1 MB");
+    expect(formatFileSize(1024 ** 2 * 5, "MB")).toBe("5 MB");
+  });
+
+  it("formats GB", () => {
+    expect(formatFileSize(1024 ** 3, "GB")).toBe("1 GB");
+    expect(formatFileSize(1024 ** 3 * 2, "GB")).toBe("2 GB");
+  });
+});

--- a/src/helpers/formatFileSize.test.ts
+++ b/src/helpers/formatFileSize.test.ts
@@ -35,4 +35,19 @@ describe("formatFileSize", () => {
     expect(formatFileSize(1024 ** 3, "GB")).toBe("1 GB");
     expect(formatFileSize(1024 ** 3 * 2, "GB")).toBe("2 GB");
   });
+
+  it("formats TB", () => {
+    expect(formatFileSize(1024 ** 4, "TB")).toBe("1 TB");
+    expect(formatFileSize(1024 ** 4 * 3, "TB")).toBe("3 TB");
+  });
+
+  it("formats PB", () => {
+    expect(formatFileSize(1024 ** 5, "PB")).toBe("1 PB");
+    expect(formatFileSize(1024 ** 5 * 4, "PB")).toBe("4 PB");
+  });
+
+  it("formats EB", () => {
+    expect(formatFileSize(1024 ** 6, "EB")).toBe("1 EB");
+    expect(formatFileSize(1024 ** 6 * 2, "EB")).toBe("2 EB");
+  });
 });

--- a/src/helpers/formatFileSize.test.ts
+++ b/src/helpers/formatFileSize.test.ts
@@ -3,51 +3,51 @@ import { formatFileSize } from "./formatFileSize";
 
 describe("formatFileSize", () => {
   it("defaults to KB", () => {
-    expect(formatFileSize(2048)).toBe("2 KB");
+    expect(formatFileSize(2048)).toBe("2KB");
   });
 
   it("rounds to the nearest whole unit", () => {
-    expect(formatFileSize(1536)).toBe("2 KB"); // 1.5 KB rounds up
-    expect(formatFileSize(1480)).toBe("1 KB"); // 1.44 KB rounds down
+    expect(formatFileSize(1536)).toBe("2KB"); // 1.5 KB rounds up
+    expect(formatFileSize(1480)).toBe("1KB"); // 1.44 KB rounds down
   });
 
   it("never returns less than 1 of the unit", () => {
-    expect(formatFileSize(0)).toBe("1 KB");
-    expect(formatFileSize(10)).toBe("1 KB");
-    expect(formatFileSize(0, "B")).toBe("1 B");
+    expect(formatFileSize(0)).toBe("1KB");
+    expect(formatFileSize(10)).toBe("1KB");
+    expect(formatFileSize(0, "B")).toBe("1B");
   });
 
   it("formats bytes", () => {
-    expect(formatFileSize(500, "B")).toBe("500 B");
+    expect(formatFileSize(500, "B")).toBe("500B");
   });
 
   it("formats KB", () => {
-    expect(formatFileSize(1024, "KB")).toBe("1 KB");
-    expect(formatFileSize(1024 * 10, "KB")).toBe("10 KB");
+    expect(formatFileSize(1024, "KB")).toBe("1KB");
+    expect(formatFileSize(1024 * 10, "KB")).toBe("10KB");
   });
 
   it("formats MB", () => {
-    expect(formatFileSize(1024 ** 2, "MB")).toBe("1 MB");
-    expect(formatFileSize(1024 ** 2 * 5, "MB")).toBe("5 MB");
+    expect(formatFileSize(1024 ** 2, "MB")).toBe("1MB");
+    expect(formatFileSize(1024 ** 2 * 5, "MB")).toBe("5MB");
   });
 
   it("formats GB", () => {
-    expect(formatFileSize(1024 ** 3, "GB")).toBe("1 GB");
-    expect(formatFileSize(1024 ** 3 * 2, "GB")).toBe("2 GB");
+    expect(formatFileSize(1024 ** 3, "GB")).toBe("1GB");
+    expect(formatFileSize(1024 ** 3 * 2, "GB")).toBe("2GB");
   });
 
   it("formats TB", () => {
-    expect(formatFileSize(1024 ** 4, "TB")).toBe("1 TB");
-    expect(formatFileSize(1024 ** 4 * 3, "TB")).toBe("3 TB");
+    expect(formatFileSize(1024 ** 4, "TB")).toBe("1TB");
+    expect(formatFileSize(1024 ** 4 * 3, "TB")).toBe("3TB");
   });
 
   it("formats PB", () => {
-    expect(formatFileSize(1024 ** 5, "PB")).toBe("1 PB");
-    expect(formatFileSize(1024 ** 5 * 4, "PB")).toBe("4 PB");
+    expect(formatFileSize(1024 ** 5, "PB")).toBe("1PB");
+    expect(formatFileSize(1024 ** 5 * 4, "PB")).toBe("4PB");
   });
 
   it("formats EB", () => {
-    expect(formatFileSize(1024 ** 6, "EB")).toBe("1 EB");
-    expect(formatFileSize(1024 ** 6 * 2, "EB")).toBe("2 EB");
+    expect(formatFileSize(1024 ** 6, "EB")).toBe("1EB");
+    expect(formatFileSize(1024 ** 6 * 2, "EB")).toBe("2EB");
   });
 });

--- a/src/helpers/formatFileSize.ts
+++ b/src/helpers/formatFileSize.ts
@@ -1,0 +1,23 @@
+type FileSizeUnit = "B" | "KB" | "MB" | "GB";
+
+const BYTES_PER_UNIT: Record<FileSizeUnit, number> = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 ** 2,
+  GB: 1024 ** 3,
+};
+
+/**
+ * Formats a byte count into the requested unit, suffixed with the unit label
+ * (e.g. `formatFileSize(2048)` => `"2 KB"`, `formatFileSize(5_242_880, "MB")` => `"5 MB"`).
+ *
+ * Rounds to the nearest whole unit and never returns less than 1, so small files
+ * don't display as "0 KB".
+ *
+ * @param bytes - Size in bytes
+ * @param unit - Unit to format to (defaults to "KB")
+ */
+export const formatFileSize = (
+  bytes: number,
+  unit: FileSizeUnit = "KB"
+): string => `${Math.max(1, Math.round(bytes / BYTES_PER_UNIT[unit]))}${unit}`;

--- a/src/helpers/formatFileSize.ts
+++ b/src/helpers/formatFileSize.ts
@@ -1,10 +1,13 @@
-type FileSizeUnit = "B" | "KB" | "MB" | "GB";
+type FileSizeUnit = "B" | "KB" | "MB" | "GB" | "TB" | "PB" | "EB";
 
 const BYTES_PER_UNIT: Record<FileSizeUnit, number> = {
   B: 1,
   KB: 1024,
   MB: 1024 ** 2,
   GB: 1024 ** 3,
+  TB: 1024 ** 4,
+  PB: 1024 ** 5,
+  EB: 1024 ** 6,
 };
 
 /**


### PR DESCRIPTION
Transforms a number of bytes into a string containing a byte-unit (MB, GB, KB). Eg 10000 bytes -> "10KB"